### PR TITLE
Fix: Improve CI workflow by packaging innovation_system

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r innovation_system/requirements.txt
+        pip install -e . # Add this line
         # Optional: Pre-download NLTK resources if tests might need them and can't download in CI
         # This assumes tests that use NLTK are robust enough to handle missing resources or you pre-populate
         # For a CI environment, explicitly downloading is often better if tests rely on them:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,31 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "innovation_system"
+version = "0.1.0"
+description = "A system for innovation."
+readme = "README.md"
+requires-python = ">=3.7"
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "License :: OSI Approved :: MIT License", # Assuming MIT, adjust if different
+    "Operating System :: OS Independent",
+]
+# Add dependencies here if they are not already in requirements.txt
+# or if you want to specify them for the package build.
+# For now, we'll rely on requirements.txt for CI.
+# dependencies = [
+#     "requests",
+#     "pandas",
+#     # etc.
+# ]
+
+[project.urls]
+"Homepage" = "https://github.com/yourusername/yourrepository" # TODO: Update with actual URL
+"Bug Tracker" = "https://github.com/yourusername/yourrepository/issues" # TODO: Update with actual URL
+
+# Optional: If you have console scripts
+# [project.scripts]
+# script-name = "innovation_system.main:run"


### PR DESCRIPTION
This change introduces a `pyproject.toml` file to define `innovation_system` as an installable Python package.

The GitHub Actions workflow (`.github/workflows/ci.yml`) has been updated to install this package using `pip install -e .` before running tests. This ensures that the package is correctly installed and importable during CI, addressing potential import errors in tests.

The pytest command remains targeted at `innovation_system/tests/`, which should now execute correctly in the context of the installed package.